### PR TITLE
Fixed unwanted exception being thrown on body.

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -10,7 +10,7 @@ module.exports = function() {
 	return function * (next) {
 		debug('init koa-validate');
 		this.checkBody = function(key) {
-			var body =  this.request.body.fields || this.request.body;	// koa-body fileds
+			var body = this.request.body ? this.request.body.fields || this.request.body : {}; // koa-body fileds
 			return new Validator(this, key, body[key], key in body , body );
 		};
 		this.checkQuery = function(key) {


### PR DESCRIPTION
When no body is passed, the validation should still be fired. Previous line of code assumed that some sort of body was being passed. Error was `TypeError: Cannot read property 'fields' of null`. This would hit on the first `checkBody()` call. With this fix, when no body is passed, the validation returns as intended.