### PR TITLE
Added support to parse objects and arrays in the request for both params and body

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -10,7 +10,8 @@ module.exports = function() {
 	return function * (next) {
 		debug('init koa-validate');
 		this.checkQuery = function(key) {
-			return new Validator(this, key, this.request.query[key], key in this.request.query,this.request.query);
+			var value = parseKey(key, this.request.query);
+			return new Validator(this, key, value, typeof value !== 'undefined',this.request.query);
 		};
 		this.checkParams = function(key) {
 			return new Validator(this, key, this.params[key], key in this.params,this.params);
@@ -22,10 +23,11 @@ module.exports = function() {
 				if(!this.errors){
 					this.errors = ['no body to check'];
 				}
-				return new Validator(this, null, null,false, null ,false ); 
+				return new Validator(this, null, null,false, null ,false );
 			}
 			var body =  body.fields || body;	// koa-body fileds. multipart fields in body.fields
-			return new Validator(this, key, body[key], key in body , body);
+			var value = parseKey(key, body);
+			return new Validator(this, key, value, typeof value !== 'undefined', body);
 		};
 		this.checkFile = function(key , deleteOnCheckFailed) {
 			if('undefined' == typeof this.request.body || 'undefined' == typeof this.request.body.files ) {
@@ -43,6 +45,20 @@ module.exports = function() {
 
 };
 
+function parseKey(key, data){
+	var value;
+	var key = (typeof key === 'number') ? [key] : key.split('.').filter(function(e){ return e !== ''; });
+
+	key.map(function(item){
+		if(typeof value === 'undefined'){
+			value = data && data[item];
+		}else{
+			value = value[item];
+		}
+	});
+
+	return value;
+}
 
 var v = require('validator');
 
@@ -620,7 +636,7 @@ function coFsCopy(src,dst){
 		var dstSteam = fs.createWriteStream(dst);
 
 		srcStream.pipe(dstSteam);
-		srcStream.on('end', function() { 
+		srcStream.on('end', function() {
 			done();
 		});
 		srcStream.on('error', function(e) {


### PR DESCRIPTION
The change is pretty light weight that allows nested object bodies and array notations in URLS to be validated using a '.' separator

http://localhost:3000?foo[bar]=foobar can be validated as
 
```javascript
this.checkQuery('foo.bar').eq('foobar')
```

the above example would require the koa-qs library to parse the get params

Also a body of 

```
{
  "foo": [{"bar": "foobar"}]
}
```

can be validated using 

```javascript
this.checkBody('foo.0.bar').eq('foobar', 'Needs to be foobar');
```

I have worked with nested bodies in many projects and this would really useful if you can merge the request.