### PR TITLE
Removed the double space in the isNumeric tip

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -255,7 +255,7 @@ Validator.prototype.isAlpha = function(tip) {
 };
 Validator.prototype.isNumeric = function(tip) {
 	if (this.goOn && !v.isNumeric(this.value)) {
-		this.addError(tip || this.key + " is  not numeric.");
+		this.addError(tip || this.key + " is not numeric.");
 	}
 	return this;
 };


### PR DESCRIPTION
This removes the double space in the isNumeric validation tip